### PR TITLE
rate limit the product migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
 		"test": "prettier --check . && xo && ava",
 		"check": "biome check --write ./src"
 	},
-	"files": ["dist", "bin"],
+	"files": [
+		"dist",
+		"bin"
+	],
 	"dependencies": {
 		"@inkjs/ui": "^2.0.0",
 		"@lemonsqueezy/lemonsqueezy.js": "^4.0.0",
@@ -26,6 +29,7 @@
 		"meow": "^11.0.0",
 		"mime-types": "^2.1.35",
 		"open": "^10.1.0",
+		"p-queue": "^8.1.0",
 		"prompts": "^2.4.2",
 		"react": "^18.2.0",
 		"standardwebhooks": "1.0.0",
@@ -56,7 +60,9 @@
 			"ts": "module",
 			"tsx": "module"
 		},
-		"nodeArguments": ["--loader=ts-node/esm"]
+		"nodeArguments": [
+			"--loader=ts-node/esm"
+		]
 	},
 	"xo": {
 		"extends": "xo-react",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       open:
         specifier: ^10.1.0
         version: 10.1.0
+      p-queue:
+        specifier: ^8.1.0
+        version: 8.1.0
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
@@ -1414,6 +1417,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -2380,9 +2386,17 @@ packages:
     resolution: {integrity: sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==}
     engines: {node: '>=12'}
 
+  p-queue@8.1.0:
+    resolution: {integrity: sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==}
+    engines: {node: '>=18'}
+
   p-timeout@5.1.0:
     resolution: {integrity: sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==}
     engines: {node: '>=12'}
+
+  p-timeout@6.1.4:
+    resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
+    engines: {node: '>=14.16'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -4639,6 +4653,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@5.0.1: {}
+
   events@3.3.0: {}
 
   execa@5.1.1:
@@ -5582,7 +5598,14 @@ snapshots:
     dependencies:
       aggregate-error: 4.0.1
 
+  p-queue@8.1.0:
+    dependencies:
+      eventemitter3: 5.0.1
+      p-timeout: 6.1.4
+
   p-timeout@5.1.0: {}
+
+  p-timeout@6.1.4: {}
 
   p-try@2.2.0: {}
 

--- a/src/product.ts
+++ b/src/product.ts
@@ -1,27 +1,27 @@
-import fs from 'node:fs';
-import https from 'node:https';
-import os from 'node:os';
-import path from 'node:path';
+import fs from "node:fs";
+import https from "node:https";
+import os from "node:os";
+import path from "node:path";
 import {
 	type ListProducts,
 	type ListVariants,
 	listFiles,
-} from '@lemonsqueezy/lemonsqueezy.js';
-import type {Polar} from '@polar-sh/sdk';
-import type {Timeframe} from '@polar-sh/sdk/models/components/benefitlicensekeyexpirationproperties.js';
-import type {BenefitLicenseKeyExpirationProperties} from '@polar-sh/sdk/models/components/benefitlicensekeyexpirationproperties.js';
-import type {FileRead} from '@polar-sh/sdk/models/components/listresourcefileread.js';
-import type {Organization} from '@polar-sh/sdk/models/components/organization.js';
-import type {Product} from '@polar-sh/sdk/models/components/product.js';
-import type {ProductCreate} from '@polar-sh/sdk/models/components/productcreate.js';
-import type {ProductPriceCustomCreate} from '@polar-sh/sdk/models/components/productpricecustomcreate.js';
-import type {ProductPriceFixedCreate} from '@polar-sh/sdk/models/components/productpricefixedcreate.js';
-import type {ProductPriceFreeCreate} from '@polar-sh/sdk/models/components/productpricefreecreate.js';
-import type {SubscriptionRecurringInterval} from '@polar-sh/sdk/models/components/subscriptionrecurringinterval.js';
-import mime from 'mime-types';
-import PQueue from 'p-queue';
-import {uploadFailedMessage, uploadMessage} from './ui/upload.js';
-import {Upload} from './upload.js';
+} from "@lemonsqueezy/lemonsqueezy.js";
+import type { Polar } from "@polar-sh/sdk";
+import type { Timeframe } from "@polar-sh/sdk/models/components/benefitlicensekeyexpirationproperties.js";
+import type { BenefitLicenseKeyExpirationProperties } from "@polar-sh/sdk/models/components/benefitlicensekeyexpirationproperties.js";
+import type { FileRead } from "@polar-sh/sdk/models/components/listresourcefileread.js";
+import type { Organization } from "@polar-sh/sdk/models/components/organization.js";
+import type { Product } from "@polar-sh/sdk/models/components/product.js";
+import type { ProductCreate } from "@polar-sh/sdk/models/components/productcreate.js";
+import type { ProductPriceCustomCreate } from "@polar-sh/sdk/models/components/productpricecustomcreate.js";
+import type { ProductPriceFixedCreate } from "@polar-sh/sdk/models/components/productpricefixedcreate.js";
+import type { ProductPriceFreeCreate } from "@polar-sh/sdk/models/components/productpricefreecreate.js";
+import type { SubscriptionRecurringInterval } from "@polar-sh/sdk/models/components/subscriptionrecurringinterval.js";
+import mime from "mime-types";
+import PQueue from "p-queue";
+import { uploadFailedMessage, uploadMessage } from "./ui/upload.js";
+import { Upload } from "./upload.js";
 
 const polarAPIQueue = new PQueue({
 	concurrency: 2,
@@ -35,30 +35,30 @@ const fileOperationsQueue = new PQueue({
 });
 
 const resolveInterval = (
-	interval: ListVariants['data'][number]['attributes']['interval'],
+	interval: ListVariants["data"][number]["attributes"]["interval"],
 ): SubscriptionRecurringInterval | null => {
 	switch (interval) {
-		case 'month':
-			return 'month';
-		case 'year':
-			return 'year';
+		case "month":
+			return "month";
+		case "year":
+			return "year";
 		default:
 			return null;
 	}
 };
 
 const resolvePrice = (
-	variant: ListVariants['data'][number],
+	variant: ListVariants["data"][number],
 ):
 	| ProductPriceFixedCreate
 	| ProductPriceFreeCreate
 	| ProductPriceCustomCreate => {
-	const priceCurrency = 'usd';
+	const priceCurrency = "usd";
 	const priceAmount = variant.attributes.price;
 
 	if (priceAmount > 0) {
 		return {
-			amountType: 'fixed',
+			amountType: "fixed",
 			priceAmount,
 			priceCurrency,
 		};
@@ -68,7 +68,7 @@ const resolvePrice = (
 
 	if (payWhatYouWant) {
 		return {
-			amountType: 'custom',
+			amountType: "custom",
 			priceAmount,
 			priceCurrency,
 			minimumAmount:
@@ -79,31 +79,31 @@ const resolvePrice = (
 
 	if (priceAmount > 0) {
 		return {
-			amountType: 'fixed',
+			amountType: "fixed",
 			priceAmount,
 			priceCurrency,
 		} as ProductPriceFixedCreate;
 	}
 
 	return {
-		amountType: 'free',
+		amountType: "free",
 	};
 };
 
 const resolveLicenseKeyExpiration = (
-	variant: ListVariants['data'][number],
+	variant: ListVariants["data"][number],
 ): BenefitLicenseKeyExpirationProperties => {
 	let timeframe: Timeframe;
 
 	switch (variant.attributes.license_length_unit) {
-		case 'days':
-			timeframe = 'day';
+		case "days":
+			timeframe = "day";
 			break;
-		case 'months':
-			timeframe = 'month';
+		case "months":
+			timeframe = "month";
 			break;
-		case 'years':
-			timeframe = 'year';
+		case "years":
+			timeframe = "year";
 			break;
 	}
 
@@ -116,14 +116,14 @@ const resolveLicenseKeyExpiration = (
 export const createProduct = async (
 	api: Polar,
 	organization: Organization,
-	variant: ListVariants['data'][number],
-	lemonProduct: ListProducts['data'][number],
+	variant: ListVariants["data"][number],
+	lemonProduct: ListProducts["data"][number],
 ) => {
 	const price = resolvePrice(variant);
-	const isDefault = variant.attributes.name === 'Default';
+	const isDefault = variant.attributes.name === "Default";
 
 	const productName = isDefault
-		? lemonProduct?.attributes.name ?? variant.attributes.name
+		? (lemonProduct?.attributes.name ?? variant.attributes.name)
 		: `${lemonProduct?.attributes.name} - ${variant.attributes.name}`;
 
 	const description = isDefault
@@ -146,13 +146,13 @@ export const createProduct = async (
 	);
 
 	if (!product) {
-		throw new Error('Product creation failed');
+		throw new Error("Product creation failed");
 	}
 
 	if (variant.attributes.has_license_keys) {
 		const benefit = await polarAPIQueue.add(() =>
 			api.benefits.create({
-				type: 'license_keys',
+				type: "license_keys",
 				description: `${productName.slice(0, 28)} License Key`,
 				properties: {
 					expires: variant.attributes.is_license_length_unlimited
@@ -163,14 +163,14 @@ export const createProduct = async (
 						: {
 								limit: variant.attributes.license_activation_limit,
 								enableCustomerAdmin: true,
-						  },
+							},
 				},
 				organizationId: organization.id,
 			}),
 		);
 
 		if (!benefit) {
-			throw new Error('Product creation failed');
+			throw new Error("Product creation failed");
 		}
 
 		await polarAPIQueue.add(() =>
@@ -198,7 +198,7 @@ export const createProduct = async (
 const handleFiles = async (
 	api: Polar,
 	organization: Organization,
-	variant: ListVariants['data'][number],
+	variant: ListVariants["data"][number],
 	product: Product,
 ) => {
 	const filesResponse = await polarAPIQueue.add(() =>
@@ -210,17 +210,17 @@ const handleFiles = async (
 	);
 
 	if (!filesResponse) {
-		throw new Error('Files response failed');
+		throw new Error("Files response failed");
 	}
 
 	// Group files with same variant id and download them
-	const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'polar-'));
+	const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "polar-"));
 
 	const groupedFiles =
 		filesResponse.data?.data?.reduce<
-			Record<string, {downloadUrl: string; filePath: string}[]>
+			Record<string, { downloadUrl: string; filePath: string }[]>
 		>((acc, file) => {
-			if ('attributes' in file && 'variant_id' in file.attributes) {
+			if ("attributes" in file && "variant_id" in file.attributes) {
 				const filePath = path.join(tempDir, file.attributes.name);
 				const url = new URL(file.attributes.download_url);
 
@@ -239,7 +239,7 @@ const handleFiles = async (
 	await Promise.all(
 		Object.values(groupedFiles)
 			.flat()
-			.map(file =>
+			.map((file) =>
 				fileOperationsQueue.add(() =>
 					downloadFile(file.downloadUrl, file.filePath),
 				),
@@ -248,7 +248,7 @@ const handleFiles = async (
 
 	// Create one benefit per variant, upload the files to the benefit, and add the benefit to the product
 	for (const [_, files] of Object.entries(groupedFiles)) {
-		const uploadPromises = files.map(file =>
+		const uploadPromises = files.map((file) =>
 			fileOperationsQueue.add<FileRead>(() =>
 				uploadFile(api, organization, file.filePath),
 			),
@@ -264,17 +264,17 @@ const handleFiles = async (
 
 		const benefit = await polarAPIQueue.add(() =>
 			api.benefits.create({
-				type: 'downloadables',
+				type: "downloadables",
 				description: product.name,
 				properties: {
-					files: validFileUploads.map(file => file.id),
+					files: validFileUploads.map((file) => file.id),
 				},
 				organizationId: organization.id,
 			}),
 		);
 
 		if (!benefit) {
-			throw new Error('Benefit creation failed');
+			throw new Error("Benefit creation failed");
 		}
 
 		await polarAPIQueue.add(() =>
@@ -291,7 +291,7 @@ const handleFiles = async (
 	await Promise.all(
 		Object.values(groupedFiles)
 			.flat()
-			.map(file => fs.promises.unlink(file.filePath)),
+			.map((file) => fs.promises.unlink(file.filePath)),
 	);
 
 	await fs.promises.rmdir(tempDir);
@@ -300,17 +300,17 @@ const handleFiles = async (
 const downloadFile = (url: string, filePath: string) => {
 	return new Promise<void>((resolve, reject) => {
 		const options = {
-			method: 'GET',
+			method: "GET",
 			headers: {
-				'Content-Type': 'application/octet-stream',
+				"Content-Type": "application/octet-stream",
 			},
 		};
 
 		const writer = fs.createWriteStream(filePath);
 
-		const request = https.get(url, options, response => {
+		const request = https.get(url, options, (response) => {
 			if (response.statusCode !== 200) {
-				fs.unlink(filePath, e => {
+				fs.unlink(filePath, (e) => {
 					if (e) {
 						console.error(e);
 					}
@@ -321,26 +321,26 @@ const downloadFile = (url: string, filePath: string) => {
 
 			response.pipe(writer);
 
-			writer.on('finish', () => {
+			writer.on("finish", () => {
 				writer.close();
 				resolve();
 			});
 		});
 
-		request.on('error', err => {
+		request.on("error", (err) => {
 			console.error(err);
 
-			fs.unlink(filePath, e => {
+			fs.unlink(filePath, (e) => {
 				if (e) {
 					console.error(e);
 				}
 			});
 		});
 
-		writer.on('error', err => {
+		writer.on("error", (err) => {
 			console.error(err);
 
-			fs.unlink(filePath, e => {
+			fs.unlink(filePath, (e) => {
 				if (e) {
 					console.error(e);
 				}
@@ -357,9 +357,9 @@ const uploadFile = async (
 	filePath: string,
 ) => {
 	const readStream = fs.createReadStream(filePath);
-	const mimeType = mime.lookup(filePath) || 'application/octet-stream';
+	const mimeType = mime.lookup(filePath) || "application/octet-stream";
 
-	const fileUploadPromise = new Promise<FileRead>(resolve => {
+	const fileUploadPromise = new Promise<FileRead>((resolve) => {
 		const upload = new Upload(api, {
 			organization,
 			file: {

--- a/src/product.ts
+++ b/src/product.ts
@@ -1,27 +1,27 @@
-import fs from "node:fs";
-import https from "node:https";
-import os from "node:os";
-import path from "node:path";
+import fs from 'node:fs';
+import https from 'node:https';
+import os from 'node:os';
+import path from 'node:path';
 import {
 	type ListProducts,
 	type ListVariants,
 	listFiles,
-} from "@lemonsqueezy/lemonsqueezy.js";
-import type { Polar } from "@polar-sh/sdk";
-import type { Timeframe } from "@polar-sh/sdk/models/components/benefitlicensekeyexpirationproperties.js";
-import type { BenefitLicenseKeyExpirationProperties } from "@polar-sh/sdk/models/components/benefitlicensekeyexpirationproperties.js";
-import type { FileRead } from "@polar-sh/sdk/models/components/listresourcefileread.js";
-import type { Organization } from "@polar-sh/sdk/models/components/organization.js";
-import type { Product } from "@polar-sh/sdk/models/components/product.js";
-import type { ProductCreate } from "@polar-sh/sdk/models/components/productcreate.js";
-import type { ProductPriceCustomCreate } from "@polar-sh/sdk/models/components/productpricecustomcreate.js";
-import type { ProductPriceFixedCreate } from "@polar-sh/sdk/models/components/productpricefixedcreate.js";
-import type { ProductPriceFreeCreate } from "@polar-sh/sdk/models/components/productpricefreecreate.js";
-import type { SubscriptionRecurringInterval } from "@polar-sh/sdk/models/components/subscriptionrecurringinterval.js";
-import mime from "mime-types";
-import PQueue from "p-queue";
-import { uploadFailedMessage, uploadMessage } from "./ui/upload.js";
-import { Upload } from "./upload.js";
+} from '@lemonsqueezy/lemonsqueezy.js';
+import type {Polar} from '@polar-sh/sdk';
+import type {Timeframe} from '@polar-sh/sdk/models/components/benefitlicensekeyexpirationproperties.js';
+import type {BenefitLicenseKeyExpirationProperties} from '@polar-sh/sdk/models/components/benefitlicensekeyexpirationproperties.js';
+import type {FileRead} from '@polar-sh/sdk/models/components/listresourcefileread.js';
+import type {Organization} from '@polar-sh/sdk/models/components/organization.js';
+import type {Product} from '@polar-sh/sdk/models/components/product.js';
+import type {ProductCreate} from '@polar-sh/sdk/models/components/productcreate.js';
+import type {ProductPriceCustomCreate} from '@polar-sh/sdk/models/components/productpricecustomcreate.js';
+import type {ProductPriceFixedCreate} from '@polar-sh/sdk/models/components/productpricefixedcreate.js';
+import type {ProductPriceFreeCreate} from '@polar-sh/sdk/models/components/productpricefreecreate.js';
+import type {SubscriptionRecurringInterval} from '@polar-sh/sdk/models/components/subscriptionrecurringinterval.js';
+import mime from 'mime-types';
+import PQueue from 'p-queue';
+import {uploadFailedMessage, uploadMessage} from './ui/upload.js';
+import {Upload} from './upload.js';
 
 const polarAPIQueue = new PQueue({
 	concurrency: 2,
@@ -35,30 +35,30 @@ const fileOperationsQueue = new PQueue({
 });
 
 const resolveInterval = (
-	interval: ListVariants["data"][number]["attributes"]["interval"],
+	interval: ListVariants['data'][number]['attributes']['interval'],
 ): SubscriptionRecurringInterval | null => {
 	switch (interval) {
-		case "month":
-			return "month";
-		case "year":
-			return "year";
+		case 'month':
+			return 'month';
+		case 'year':
+			return 'year';
 		default:
 			return null;
 	}
 };
 
 const resolvePrice = (
-	variant: ListVariants["data"][number],
+	variant: ListVariants['data'][number],
 ):
 	| ProductPriceFixedCreate
 	| ProductPriceFreeCreate
 	| ProductPriceCustomCreate => {
-	const priceCurrency = "usd";
+	const priceCurrency = 'usd';
 	const priceAmount = variant.attributes.price;
 
 	if (priceAmount > 0) {
 		return {
-			amountType: "fixed",
+			amountType: 'fixed',
 			priceAmount,
 			priceCurrency,
 		};
@@ -68,7 +68,7 @@ const resolvePrice = (
 
 	if (payWhatYouWant) {
 		return {
-			amountType: "custom",
+			amountType: 'custom',
 			priceAmount,
 			priceCurrency,
 			minimumAmount:
@@ -79,31 +79,31 @@ const resolvePrice = (
 
 	if (priceAmount > 0) {
 		return {
-			amountType: "fixed",
+			amountType: 'fixed',
 			priceAmount,
 			priceCurrency,
 		} as ProductPriceFixedCreate;
 	}
 
 	return {
-		amountType: "free",
+		amountType: 'free',
 	};
 };
 
 const resolveLicenseKeyExpiration = (
-	variant: ListVariants["data"][number],
+	variant: ListVariants['data'][number],
 ): BenefitLicenseKeyExpirationProperties => {
 	let timeframe: Timeframe;
 
 	switch (variant.attributes.license_length_unit) {
-		case "days":
-			timeframe = "day";
+		case 'days':
+			timeframe = 'day';
 			break;
-		case "months":
-			timeframe = "month";
+		case 'months':
+			timeframe = 'month';
 			break;
-		case "years":
-			timeframe = "year";
+		case 'years':
+			timeframe = 'year';
 			break;
 	}
 
@@ -116,14 +116,14 @@ const resolveLicenseKeyExpiration = (
 export const createProduct = async (
 	api: Polar,
 	organization: Organization,
-	variant: ListVariants["data"][number],
-	lemonProduct: ListProducts["data"][number],
+	variant: ListVariants['data'][number],
+	lemonProduct: ListProducts['data'][number],
 ) => {
 	const price = resolvePrice(variant);
-	const isDefault = variant.attributes.name === "Default";
+	const isDefault = variant.attributes.name === 'Default';
 
 	const productName = isDefault
-		? (lemonProduct?.attributes.name ?? variant.attributes.name)
+		? lemonProduct?.attributes.name ?? variant.attributes.name
 		: `${lemonProduct?.attributes.name} - ${variant.attributes.name}`;
 
 	const description = isDefault
@@ -146,13 +146,13 @@ export const createProduct = async (
 	);
 
 	if (!product) {
-		throw new Error("Product creation failed");
+		throw new Error('Product creation failed');
 	}
 
 	if (variant.attributes.has_license_keys) {
 		const benefit = await polarAPIQueue.add(() =>
 			api.benefits.create({
-				type: "license_keys",
+				type: 'license_keys',
 				description: `${productName.slice(0, 28)} License Key`,
 				properties: {
 					expires: variant.attributes.is_license_length_unlimited
@@ -163,14 +163,14 @@ export const createProduct = async (
 						: {
 								limit: variant.attributes.license_activation_limit,
 								enableCustomerAdmin: true,
-							},
+						  },
 				},
 				organizationId: organization.id,
 			}),
 		);
 
 		if (!benefit) {
-			throw new Error("Product creation failed");
+			throw new Error('Product creation failed');
 		}
 
 		await polarAPIQueue.add(() =>
@@ -198,7 +198,7 @@ export const createProduct = async (
 const handleFiles = async (
 	api: Polar,
 	organization: Organization,
-	variant: ListVariants["data"][number],
+	variant: ListVariants['data'][number],
 	product: Product,
 ) => {
 	const filesResponse = await polarAPIQueue.add(() =>
@@ -210,17 +210,17 @@ const handleFiles = async (
 	);
 
 	if (!filesResponse) {
-		throw new Error("Files response failed");
+		throw new Error('Files response failed');
 	}
 
 	// Group files with same variant id and download them
-	const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "polar-"));
+	const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'polar-'));
 
 	const groupedFiles =
 		filesResponse.data?.data?.reduce<
-			Record<string, { downloadUrl: string; filePath: string }[]>
+			Record<string, {downloadUrl: string; filePath: string}[]>
 		>((acc, file) => {
-			if ("attributes" in file && "variant_id" in file.attributes) {
+			if ('attributes' in file && 'variant_id' in file.attributes) {
 				const filePath = path.join(tempDir, file.attributes.name);
 				const url = new URL(file.attributes.download_url);
 
@@ -239,7 +239,7 @@ const handleFiles = async (
 	await Promise.all(
 		Object.values(groupedFiles)
 			.flat()
-			.map((file) =>
+			.map(file =>
 				fileOperationsQueue.add(() =>
 					downloadFile(file.downloadUrl, file.filePath),
 				),
@@ -248,7 +248,7 @@ const handleFiles = async (
 
 	// Create one benefit per variant, upload the files to the benefit, and add the benefit to the product
 	for (const [_, files] of Object.entries(groupedFiles)) {
-		const uploadPromises = files.map((file) =>
+		const uploadPromises = files.map(file =>
 			fileOperationsQueue.add<FileRead>(() =>
 				uploadFile(api, organization, file.filePath),
 			),
@@ -264,17 +264,17 @@ const handleFiles = async (
 
 		const benefit = await polarAPIQueue.add(() =>
 			api.benefits.create({
-				type: "downloadables",
+				type: 'downloadables',
 				description: product.name,
 				properties: {
-					files: validFileUploads.map((file) => file.id),
+					files: validFileUploads.map(file => file.id),
 				},
 				organizationId: organization.id,
 			}),
 		);
 
 		if (!benefit) {
-			throw new Error("Benefit creation failed");
+			throw new Error('Benefit creation failed');
 		}
 
 		await polarAPIQueue.add(() =>
@@ -291,7 +291,7 @@ const handleFiles = async (
 	await Promise.all(
 		Object.values(groupedFiles)
 			.flat()
-			.map((file) => fs.promises.unlink(file.filePath)),
+			.map(file => fs.promises.unlink(file.filePath)),
 	);
 
 	await fs.promises.rmdir(tempDir);
@@ -300,17 +300,17 @@ const handleFiles = async (
 const downloadFile = (url: string, filePath: string) => {
 	return new Promise<void>((resolve, reject) => {
 		const options = {
-			method: "GET",
+			method: 'GET',
 			headers: {
-				"Content-Type": "application/octet-stream",
+				'Content-Type': 'application/octet-stream',
 			},
 		};
 
 		const writer = fs.createWriteStream(filePath);
 
-		const request = https.get(url, options, (response) => {
+		const request = https.get(url, options, response => {
 			if (response.statusCode !== 200) {
-				fs.unlink(filePath, (e) => {
+				fs.unlink(filePath, e => {
 					if (e) {
 						console.error(e);
 					}
@@ -321,26 +321,26 @@ const downloadFile = (url: string, filePath: string) => {
 
 			response.pipe(writer);
 
-			writer.on("finish", () => {
+			writer.on('finish', () => {
 				writer.close();
 				resolve();
 			});
 		});
 
-		request.on("error", (err) => {
+		request.on('error', err => {
 			console.error(err);
 
-			fs.unlink(filePath, (e) => {
+			fs.unlink(filePath, e => {
 				if (e) {
 					console.error(e);
 				}
 			});
 		});
 
-		writer.on("error", (err) => {
+		writer.on('error', err => {
 			console.error(err);
 
-			fs.unlink(filePath, (e) => {
+			fs.unlink(filePath, e => {
 				if (e) {
 					console.error(e);
 				}
@@ -355,11 +355,11 @@ const uploadFile = async (
 	api: Polar,
 	organization: Organization,
 	filePath: string,
-): Promise<FileRead> => {
+) => {
 	const readStream = fs.createReadStream(filePath);
-	const mimeType = mime.lookup(filePath) || "application/octet-stream";
+	const mimeType = mime.lookup(filePath) || 'application/octet-stream';
 
-	const fileUploadPromise = new Promise<FileRead>((resolve) => {
+	const fileUploadPromise = new Promise<FileRead>(resolve => {
 		const upload = new Upload(api, {
 			organization,
 			file: {
@@ -377,5 +377,7 @@ const uploadFile = async (
 
 	await uploadMessage(fileUploadPromise);
 
-	return await fileUploadPromise;
+	const fileUpload = await fileUploadPromise;
+
+	return fileUpload;
 };


### PR DESCRIPTION
[Related Discord thread](https://discord.com/channels/1078611507115470849/1291358900951711816/1343960292216012820)

solution for hitting the rate limits while migrating the products

after writing this, I saw that you already have `promiseAllInBatches` for migrating customers, but I belive the solution with `p-queue` is more robust and it's easier to set actual rate limits for requests, not just create batches, but still process stuff ASAP

the proposed rate limits are random-ish, just low enough that shouldn't cause any issues, since this won't need to be particularly fast anyways